### PR TITLE
Consolidate install scripts for independence and reduced duplication

### DIFF
--- a/tr2_jetson_setup/install_tr2_nano.bash
+++ b/tr2_jetson_setup/install_tr2_nano.bash
@@ -11,54 +11,16 @@ done
 
 sudo apt-get update
 
-echo "Installing ROS Kinetic"
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo -E apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
-sudo apt-get update
-sudo apt-get install ros-melodic-desktop-full -y
-sudo rosdep init
-rosdep update
-echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
-source ~/.bashrc
-sudo apt-get install python-rosinstall python-rosinstall-generator python-wstool build-essential xboxdrv -y
-sudo apt-get install ros-melodic-moveit ros-melodic-joy ros-melodic-ros-control ros-melodic-ros-controllers ros-melodic-gazebo-ros-control ros-melodic-navigation -y
-
-echo "Installing TR2 Packages"
-mkdir ~/ros_ws
-mkdir ~/ros_ws/src
-cd ~/ros_ws/src
-echo "source ~/ros_ws/devel/setup.bash" >> ~/.bashrc
-git clone https://github.com/slaterobotics/tr2_essentials
-git clone https://github.com/slaterobotics/tr2_xbox_teleop
-cd ~/ros_ws
-catkin_make
-source ~/.bashrc
-
-echo "Installing Orbbec Packages"
-cd ~/ros_ws/src
-sudo apt-get install ros-*-rgbd-launch ros-*-libuvc ros-*-libuvc-camera ros-*-libuvc-ros
-git clone https://github.com/orbbec/ros_astra_camera
-git clone https://github.com/orbbec/ros_astra_launch
-cd ~/ros_ws
-catkin_make
-source ~/.bashrc
-roscd astra_camera
-./scripts/create_udev_rules
+./ros_base.bash
+./ros_melodic.bash
+./tr2_packages.bash
+./orbecc_packages.bash
 
 echo "Configuring environment"
 sudo cp local.rules /etc/udev/rules.d/
 sudo cp orbbec-usb.rules /etc/udev/rules.d/
 
-echo "Installing Kernel USB-UART Drivers"
-mkdir ~/Documents/Github
-cd ~/Documents/Github
-sudo chmod -R 777 ~/Documents/Github
-git clone https://github.com/jetsonhacks/installACMModule
-cd installACMModule
-./installCH341.sh
-./installCP210x.sh
-./installCDCACM.sh
+./kernel_drivers.bash
 
 echo "Updating Packages"
 sudo apt-get upgrade -y

--- a/tr2_jetson_setup/install_tr2_tx2.bash
+++ b/tr2_jetson_setup/install_tr2_tx2.bash
@@ -11,42 +11,15 @@ done
 
 sudo apt-get update
 
-echo "Installing ROS Kinetic"
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-sudo -E apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-
-sudo apt-get update
-sudo apt-get install ros-kinetic-desktop-full -y
-sudo rosdep init
-rosdep update
-echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
-source ~/.bashrc
-sudo apt-get install python-rosinstall python-rosinstall-generator python-wstool build-essential xboxdrv -y
-sudo apt-get install ros-kinetic-moveit ros-kinetic-joy ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-gazebo-control ros-kinetic-astra-camera ros-kinetic-astra-launch -y
-
-echo "Installing TR2 Packages"
-mkdir ~/ros_ws
-mkdir ~/ros_ws/src
-cd ~/ros_ws/src
-echo "source ~/ros_ws/devel/setup.bash" >> ~/.bashrc
-git clone https://github.com/slaterobotics/tr2_essentials
-git clone https://github.com/slaterobotics/tr2_xbox_teleop
-cd ~/ros_ws
-catkin_make
-source ~/.bashrc
+./ros_base.bash
+./ros_kinetic.bash
+./tr2_packages.bash
 
 echo "Configuring environment"
 sudo cp local.rules /etc/udev/rules.d/
 sudo cp orbbec-usb.rules /etc/udev/rules.d/
 
-echo "Installing Kernel USB-UART Drivers"
-mkdir ~/Documents/Github
-cd ~/Documents/Github
-git clone https://github.com/jetsonhacks/installACMModule
-cd installACMModule
-./installCH341.sh
-./installCP210x.sh
-./installCDCACM.sh
+./kernel_drivers.bash
 
 echo "Updating Packages"
 sudo apt-get upgrade -y

--- a/tr2_jetson_setup/kernel_drivers.bash
+++ b/tr2_jetson_setup/kernel_drivers.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+echo "Installing Kernel USB-UART Drivers"
+mkdir ~/Documents/Github
+cd ~/Documents/Github
+git clone https://github.com/jetsonhacks/installACMModule
+cd installACMModule
+./installCH341.sh
+./installCP210x.sh
+./installCDCACM.sh

--- a/tr2_jetson_setup/orbbec_packages.bash
+++ b/tr2_jetson_setup/orbbec_packages.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+echo "Installing Orbbec Packages"
+cd ~/ros_ws/src
+sudo apt-get install ros-*-rgbd-launch ros-*-libuvc ros-*-libuvc-camera ros-*-libuvc-ros
+git clone https://github.com/orbbec/ros_astra_camera
+git clone https://github.com/orbbec/ros_astra_launch
+cd ~/ros_ws
+catkin_make
+source ~/.bashrc
+roscd astra_camera
+./scripts/create_udev_rules
+echo "Orbbec packages installed"

--- a/tr2_jetson_setup/ros_base.bash
+++ b/tr2_jetson_setup/ros_base.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+echo "Installing ROS basics"
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo -E apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+echo "ROS basics install complete"

--- a/tr2_jetson_setup/ros_kinetic.bash
+++ b/tr2_jetson_setup/ros_kinetic.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+echo "Installing ROS kinetic packages..."
+sudo apt-get update
+sudo apt-get install ros-kinetic-desktop-full -y
+sudo rosdep init
+rosdep update
+echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
+source ~/.bashrc
+sudo apt-get install python-rosinstall python-rosinstall-generator python-wstool build-essential xboxdrv -y
+sudo apt-get install ros-kinetic-moveit ros-kinetic-joy ros-kinetic-ros-control ros-kinetic-ros-controllers ros-kinetic-gazebo-control ros-kinetic-astra-camera ros-kinetic-astra-launch -y
+echo "ROS kinetic installed"

--- a/tr2_jetson_setup/ros_melodic.bash
+++ b/tr2_jetson_setup/ros_melodic.bash
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+echo "Installing ROS melodic packages..."
+sudo apt-get update
+sudo apt-get install ros-melodic-desktop-full -y
+sudo rosdep init
+rosdep update
+echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
+source ~/.bashrc
+sudo apt-get install python-rosinstall python-rosinstall-generator python-wstool build-essential xboxdrv -y
+sudo apt-get install ros-melodic-moveit ros-melodic-joy ros-melodic-ros-control ros-melodic-ros-controllers ros-melodic-gazebo-ros-control ros-melodic-navigation -y
+echo "ROS melodic installed"

--- a/tr2_jetson_setup/tr2_packages.bash
+++ b/tr2_jetson_setup/tr2_packages.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+ROS_WS="~/ros_ws"
+echo "Installing TR2 Packages at " $ROS_WS
+mkdir $ROS_WS
+mkdir $ROS_WS/src
+cd $ROS_WS/src
+echo "source ~/ros_ws/devel/setup.bash" >> ~/.bashrc
+git clone https://github.com/slaterobotics/tr2_essentials
+git clone https://github.com/slaterobotics/tr2_xbox_teleop
+cd $ROS_WS
+catkin_make
+source ~/.bashrc


### PR DESCRIPTION
Found the similarities between `install_tr2_nano.bash` and `install_tr2_tx2.bash`, made a few smaller scripts and referenced them back into these two bash files.

Main purpose was to help get startup installs done a bit easier. Now instead of cherry-picking lines out of one of these two files for new dev setup, we can just run `ros_base.bash`, `ros_melodic.bash` (or `kinetic`). The original scripts should still function as they did before.

Another pro here is if we need to update one of these steps' references or version numbers, we only have to do it in one place.